### PR TITLE
Add dynamic-theme for video player progress bar msnbc.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14795,6 +14795,18 @@ INVERT
 
 ================================
 
+msnbc.com
+
+CSS
+.styles_progress__GFuLT::-moz-progress-bar {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+.styles_progress__GFuLT {
+    background-color: #666 !important;
+}
+
+================================
+
 msys2.org
 
 CSS


### PR DESCRIPTION
# About
The progress bar on the video player on msnbc.com was nearly impossible to see with DarkReader enabled.

# Summary of Changes
* Added foreground color override for progress bar. 
* Added background color override for progress bar. 

# Assets

![CleanShot X_001982_zbm](https://github.com/zakkhoyt/darkreader/assets/2229408/c8f36843-9dfc-4e11-9475-7bff56d56b21)
